### PR TITLE
Fixes for lightdm and Xorg support

### DIFF
--- a/files/lightdm/lightdm.conf
+++ b/files/lightdm/lightdm.conf
@@ -1,2 +1,2 @@
-[SeatDefaults]
+[Seat:*]
 display-setup-script=/etc/lightdm/xhost.sh

--- a/files/lightdm/xhost.sh
+++ b/files/lightdm/xhost.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+if [ "${DISPLAY+set}" != set ]; then
+  # TODO: assuming :0 here is fragile
+  export DISPLAY=:0.0
+fi
+
 xhost +si:localuser:root
 xhost +si:localuser:jenkins
-xhost +si:localuser:osrf

--- a/files/xorg.conf.no_gpu
+++ b/files/xorg.conf.no_gpu
@@ -1,0 +1,40 @@
+Section "ServerLayout"
+    Identifier     "Layout0"
+    InputDevice    "Keyboard0" "CoreKeyboard"
+    InputDevice    "Mouse0" "CorePointer"
+EndSection
+
+Section "Files"
+EndSection
+
+Section "InputDevice"
+    # generated from default
+    Identifier     "Mouse0"
+    Driver         "mouse"
+    Option         "Protocol" "auto"
+    Option         "Device" "/dev/psaux"
+    Option         "Emulate3Buttons" "no"
+    Option         "ZAxisMapping" "4 5"
+EndSection
+
+Section "InputDevice"
+    # generated from default
+    Identifier     "Keyboard0"
+    Driver         "kbd"
+EndSection
+
+Section "Monitor"
+    Identifier     "Monitor0"
+    VendorName     "Unknown"
+    ModelName      "Unknown"
+    HorizSync       28.0 - 33.0
+    VertRefresh     43.0 - 72.0
+    Option         "DPMS"
+EndSection
+
+Section "Screen"
+    Identifier     "Default Screen"
+    Device         "Device0"
+    Monitor        "Monitor0"
+    Option         "AllowEmptyInitialConfiguration" "True"
+EndSection

--- a/files/xorg.conf.nvidia
+++ b/files/xorg.conf.nvidia
@@ -1,0 +1,48 @@
+Section "ServerLayout"
+    Identifier     "Layout0"
+    InputDevice    "Keyboard0" "CoreKeyboard"
+    InputDevice    "Mouse0" "CorePointer"
+EndSection
+
+Section "Files"
+EndSection
+
+Section "InputDevice"
+    # generated from default
+    Identifier     "Mouse0"
+    Driver         "mouse"
+    Option         "Protocol" "auto"
+    Option         "Device" "/dev/psaux"
+    Option         "Emulate3Buttons" "no"
+    Option         "ZAxisMapping" "4 5"
+EndSection
+
+Section "InputDevice"
+    # generated from default
+    Identifier     "Keyboard0"
+    Driver         "kbd"
+EndSection
+
+Section "Monitor"
+    Identifier     "Monitor0"
+    VendorName     "Unknown"
+    ModelName      "Unknown"
+    HorizSync       28.0 - 33.0
+    VertRefresh     43.0 - 72.0
+    Option         "DPMS"
+EndSection
+
+Section "Device"
+    Identifier     "Device0"
+    Driver         "nvidia"
+    VendorName     "NVIDIA Corporation"
+    BoardName      "GRID K520"
+    BusID          "PCI:0:3:0"
+EndSection
+
+Section "Screen"
+    Identifier     "Default Screen"
+    Device         "Device0"
+    Monitor        "Monitor0"
+    Option         "AllowEmptyInitialConfiguration" "True"
+EndSection

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,10 +20,24 @@ end
   ntp
   qemu-user-static
   sudo
+  x11-xserver-utils
   wget
 ].each do |pkg|
   package pkg
 end
+
+cookbook_file '/etc/X11/xorg.conf' do
+  source 'xorg.conf.no_gpu'
+  mode "0744"
+  not_if "ls /dev/nvidia*"
+end
+cookbook_file '/etc/X11/xorg.conf' do
+  source 'xorg.conf.nvidia'
+  mode "0744"
+  only_if "ls /dev/nvidia*"
+end
+# TODO: assuming :0 here is fragile
+ENV['DISPLAY'] = ':0'
 
 package "lightdm"
 cookbook_file "/etc/lightdm/xhost.sh" do
@@ -44,6 +58,21 @@ ruby_block "Ensure display-setup-script" do
       "display-setup-script=/etc/lightdm/xhost.conf"
     lightdm_conf.write_file if lightdm_conf.unwritten_changes?
   end
+end
+
+# set lightdm as the display manager requires 3 commands
+execute 'set-lighdm-display-manager debconf' do
+  command 'echo set shared/default-x-display-manager lightdm | debconf-communicate'
+  not_if 'grep lightdm /etc/X11/default-display-manager'
+end
+execute 'reconfigure-gdm3' do
+  command 'dpkg-reconfigure lightdm'
+  environment ({'DEBIAN_FRONTEND' => 'noninteractive', 'DEBCONF_NONINTERACTIVE_SEEN' => 'true'})
+  not_if 'grep lightdm /etc/X11/default-display-manager'
+end
+execute 'set-lightdm-display-manager-etc' do
+  command 'echo "/usr/sbin/lightdm" > /etc/X11/default-display-manager'
+  not_if 'grep lightdm /etc/X11/default-display-manager'
 end
 service "lightdm" do
   action [:start, :enable]


### PR DESCRIPTION
The PR include some changes and fixes for the general Xorg support in the node:

 * Custom xorg file to work in headless mode for both gpu and not gpu
 * lightdm configuration in the system to use it instead of gdm3
 * Support to work in github actions by injecting the DISPLAY variable