### PR TITLE
Relax docker dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name "osrf_jenkins_agent"
-maintainer "Steven! Ragnarök"
-maintainer_email "steven@openrobotics.org"
+maintainer "Jose Luis Rivero"
+maintainer_email "jrivero@openrobotics.org"
 license "Apache-2.0"
 description "Configures a Jenkins agent for the OSRF build farm."
 long_description "Configures a Jenkins agent for the OSRF build farm."
-version "0.1.0"
+version "0.1.1"
 chef_version ">= 14.0"
 
 depends "docker"

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,4 +7,4 @@ long_description "Configures a Jenkins agent for the OSRF build farm."
 version "0.1.0"
 chef_version ">= 14.0"
 
-depends "docker", "~>6"
+depends "docker"


### PR DESCRIPTION
The version of docker in chef-osrf is 4. Relax the restriction so it can work with chef-solo nicely. I was receiving problems when running `chef-solo` but testing seems to be happy using `kitchen`. No idea why is this.