### PR TITLE
Support AWS and other NVIDIA cards

### DIFF
--- a/files/xorg.conf.nvidia_aws
+++ b/files/xorg.conf.nvidia_aws
@@ -36,6 +36,8 @@ Section "Device"
     Identifier     "Device0"
     Driver         "nvidia"
     VendorName     "NVIDIA Corporation"
+    BoardName      "GRID K520"
+    BusID          "PCI:0:3:0"
 EndSection
 
 Section "Screen"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,6 +10,14 @@ module OSRFJenkinsAgent
     def has_nvidia_support?
       shell_out('lspci').stdout.match?(/VGA.*NVIDIA/)
     end
+
+    # Determines if an NVIDIA card GRID is detected on the system
+    # The model is the one in AWS nodes
+    #
+    # @return [Boolean]
+    def has_nvidia_grid_support?
+      shell_out('lspci').stdout.match?(/.*NVIDIA.*GRID/)
+    end
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,14 +52,14 @@ end
 cookbook_file '/etc/X11/xorg.conf' do
   source 'xorg.conf.nvidia_aws'
   mode "0744"
-  only_if "lspci | grep '.*NVIDIA.*GRID'"
+  only_if { has_nvidia_grid_support? }
 end
 # Other NVIDIA cards use generic configuration
 cookbook_file '/etc/X11/xorg.conf' do
   source 'xorg.conf.nvidia'
   mode "0744"
   only_if { has_nvidia_support? }
-  not_if "lspci | grep '.*NVIDIA.*GRID'"
+  not_if { has_nvidia_grid_support? }
 end
 # TODO: assuming :0 here is fragile
 ENV['DISPLAY'] = ':0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,10 +36,18 @@ cookbook_file '/etc/X11/xorg.conf' do
   mode "0744"
   not_if "ls /dev/nvidia*"
 end
+# Detecting AWS GRID cards that needs special configuration
+cookbook_file '/etc/X11/xorg.conf' do
+  source 'xorg.conf.nvidia_aws'
+  mode "0744"
+  only_if "lspci | grep '.*NVIDIA.*GRID'"
+end
+# Other NVIDIA cards use generic configuration
 cookbook_file '/etc/X11/xorg.conf' do
   source 'xorg.conf.nvidia'
   mode "0744"
   only_if "ls /dev/nvidia*"
+  not_if "lspci | grep '.*NVIDIA.*GRID'"
 end
 # TODO: assuming :0 here is fragile
 ENV['DISPLAY'] = ':0'


### PR DESCRIPTION
AWS uses NVIDIA GRID cards that needs particular configuration to work nicely. That configuration broke other cards. Support both cases.
