### PR TITLE
Whitelist ros2 repositories for squi-deb-proxy

### DIFF
--- a/files/squid-deb-proxy/mirror-dstdomain.acl.d/12-osrfoundation
+++ b/files/squid-deb-proxy/mirror-dstdomain.acl.d/12-osrfoundation
@@ -2,3 +2,4 @@
 
 .osrfoundation.org
 .ros.org
+.ros2.org


### PR DESCRIPTION
I've seen failures in the ros2 repositiories jobs with 404:

```
Step 35/59 : RUN apt-get update && apt-get install -y --no-install-recommends         git         ca-certificates         make         automake         autoconf         libtool         pkg-config         python3         libxext-dev         libx11-dev         x11proto-gl-dev &&     rm -rf /var/lib/apt/lists/*
 ---> Running in 4f0434aca3db
Err:1 http://repo.ros2.org/ubuntu/main focal InRelease
  403  Forbidden [IP: 172.17.0.1 8000]
Err:2 http://repo.ros2.org/ubuntu/testing focal InRelease
  403  Forbidden [IP: 172.17.0.1 8000]
Hit:3 http://packages.osrfoundation.org/gazebo/ubuntu-stable focal InRelease
Hit:4 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Reading package lists...
E: Failed to fetch http://repo.ros2.org/ubuntu/main/dists/focal/InRelease  403  Forbidden [IP: 172.17.0.1 8000]
E: The repository 'http://repo.ros2.org/ubuntu/main focal InRelease' is no longer signed.
E: Failed to fetch http://repo.ros2.org/ubuntu/testing/dists/focal/InRelease  403  Forbidden [IP: 172.17.0.1 8000]
E: The repository 'http://repo.ros2.org/ubuntu/testing focal InRelease' is no longer signed.
The command '/bin/sh -c apt-get update && apt-get install -y --no-install-recommends         git         ca-certificates         make         automake         autoconf         libtool         pkg-config         python3         libxext-dev         libx11-dev         x11proto-gl-dev &&     rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Build step 'Execute shell' marked build as failure
```

This should fix the problem.
