### PR TITLE
Do not install openjdk-8-jdk-headless package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,6 @@ end
   libssl-dev
   mercurial
   ntp
-  openjdk-8-jdk-headless
   pciutils
   qemu-user-static
   sudo


### PR DESCRIPTION
Java 8 is not supported anymore.