### PR TITLE
Improve testing of agent installation

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -105,6 +105,4 @@ end
 
 service 'jenkins-agent' do
   action [:start, :enable]
-  # can not connect to server while testing
-  not_if { node.chef_environment == "test" }
 end

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -17,12 +17,12 @@ end
 
 control 'jenkins-agent' do
   impact 'critical'
-  title 'jenkins-agent service should installed, not running'
+  title 'jenkins-agent service should installed and running'
   describe service('jenkins-agent') do
     it { should be_installed }
     # imposible to connect to server in tests, should not be up
-    it { should_not be_enabled }
-    it { should_not be_running }
+    it { should be_enabled }
+    it { should be_running }
   end
 end
 


### PR DESCRIPTION
The agent installation seems to work fine while testing it in chef-osrf repository. Let's see how much we can improve in this PR. Plan is:

 * Is the agent running and enabled in github actions by default?
 * If not: let's leave the enable check and keep turned off the running check.