### PR TITLE
Refactor labels and make docker label auto-generated instead of default.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,4 +21,3 @@ default['osrfbuild']['agent']['executors'] = 1
 # if set to false, the value of ['osrfbuild']['agent']['labels']
 # is respected. Note that the value here can be overloaded.
 default['osrfbuild']['agent']['auto_generate_labels'] = true
-default['osrfbuild']['agent']['labels'] = %w(docker)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,12 +58,14 @@ end
 node_name = "linux-#{node_base_name}.focal"
 
 if has_nvidia_support?
-    node_name = "linux-#{node_base_name}.nv.focal"
-    # TODO: do not assume nvidia machines are powerful
-    node_make_jobs = 5
-    if node['osrfbuild']['agent']['auto_generate_labels']
-      node_labels += ["gpu-reliable", "gpu-nvidia", "large-memory", "large-disk"]
+  node_name = "linux-#{node_base_name}.nv.focal"
+  # TODO: do not assume nvidia machines are powerful
+  node_make_jobs = 5
+  if node['osrfbuild']['agent']['auto_generate_labels']
+    %w[gpu-reliable gpu-nvidia large-memory large-disk].each do |label|
+      node_labels << label unless node_labels.include? label
     end
+  end
 end
 
 # override node name if a nodename was given

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,15 @@ end
 jenkins_username = node['osrfbuild']['agent']['username']
 node_make_jobs = 3 # TODO: find a better way of handling make_jobs
 node_base_name = node['hostname'] == 'localhost' ? node['ipaddress'] : node['hostname']
-node_labels = [ node['osrfbuild']['agent']['labels'] ]
+node_labels = if node['osrfbuild']['agent']['labels']
+                node['osrfbuild']['agent']['labels'].dup
+              else
+                Array.new
+              end
+# All default agents are "docker" agents.
+if node['osrfbuild']['agent']['auto_generate_labels']
+  node_labels << 'docker' unless node_labels.include? 'docker'
+end
 node_name = "linux-#{node_base_name}.focal"
 
 if has_nvidia_support?


### PR DESCRIPTION
This change is prompted by the addition of recipes for macOS agents coming in a further PR.
Due to the way chef attributes are interleaved, the default `docker` label will be applied to any node which does not use an `override` level attribute to remove it (see [attribute precedence](https://docs.chef.io/attribute_precedence/) docs).

Instead, I've made the docker label unconditionally applied when auto-generated labels are enabled since the default recipe is currently for Linux agents and all current linux agents are docker agents. Changes to that assumption in the future would require additional significant changes to the recipes so I'm not too worried about that.

Since the docker label is being applied by default where applicable, I removed it from the default attributes and updated the recipe to handle a lack of default labels.

I also set it up so that labels which are defined in node attributes won't get added if they're already listed. Ruby has a Set class in the standard library which we could use but I don't think there's a justification over these little logic snippets.