### PR TITLE
Update and expand gpu instance support.

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,7 +8,7 @@ module OSRFJenkinsAgent
     #
     # @return [Array]
     def nvidia_devices
-      node['gpu_devices'].select do |_, dev|
+      node['gpu_devices'].values.select do |dev|
         dev['vendor'] =~ /nvidia/i
       end
     end
@@ -28,7 +28,7 @@ module OSRFJenkinsAgent
     #
     # @return [Boolean]
     def has_nvidia_grid_support?
-      nvidia_devices.any? { |_, dev| dev['device'] =~ /GRID/ }
+      nvidia_devices.any? { |dev| dev['device'] =~ /GRID/ }
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,6 +4,15 @@
 #
 module OSRFJenkinsAgent
   module Helpers
+    # List nvidia devices present on the system.
+    #
+    # @return [Array]
+    def nvidia_devices
+      node['gpu_devices'].select do |_, dev|
+        dev['vendor'] =~ /nvidia/i
+      end
+    end
+
     # Determines if an NVIDIA card is detected on the system
     #
     # @return [Boolean]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,11 +17,10 @@ module OSRFJenkinsAgent
     #
     # @return [Boolean]
     def has_nvidia_support?
-
       if ENV['CHEF_TEST_FAKE_NVIDIA_SUPPORT'] == 'true'
         return true
       end
-      shell_out('lspci').stdout.match?(/(?:3D|VGA).*NVIDIA/)
+      nvidia_devices.any?
     end
 
     # Determines if an NVIDIA card GRID is detected on the system
@@ -29,7 +28,7 @@ module OSRFJenkinsAgent
     #
     # @return [Boolean]
     def has_nvidia_grid_support?
-      shell_out('lspci').stdout.match?(/.*NVIDIA.*GRID/)
+      nvidia_devices.any? { |_, dev| dev['device'] =~ /GRID/ }
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -12,7 +12,7 @@ module OSRFJenkinsAgent
       if ENV['CHEF_TEST_FAKE_NVIDIA_SUPPORT'] == 'true'
         return true
       end
-      shell_out('lspci').stdout.match?(/VGA.*NVIDIA/)
+      shell_out('lspci').stdout.match?(/(?:3D|VGA).*NVIDIA/)
     end
 
     # Determines if an NVIDIA card GRID is detected on the system

--- a/ohai/gpu_devices.rb
+++ b/ohai/gpu_devices.rb
@@ -1,0 +1,24 @@
+Ohai.plugin(:GPUDevices) do
+  provides 'gpu_devices'
+
+  def gpu_devices_from_lspci
+    shell_out('lspci -vmm').stdout.split("\n\n").select do |pcidev|
+      pcidev =~ /(?:3D|VGA)(?: compatible) controller/
+    end.map do |gpudev|
+      Mash.new.tap do |properties|
+        gpudev.lines.map do |line|
+          line.chomp!
+          key, val = line.split(":\t")
+          properties[key.downcase] = val
+        end
+      end
+    end
+  end
+
+  collect_data(:linux) do
+    gpu_devices Mash.new
+    gpu_devices_from_lspci.each do |dev|
+      gpu_devices[dev['slot']] = dev
+    end
+  end
+end

--- a/ohai/gpu_devices.rb
+++ b/ohai/gpu_devices.rb
@@ -3,7 +3,7 @@ Ohai.plugin(:GPUDevices) do
 
   def gpu_devices_from_lspci
     shell_out('lspci -vmm').stdout.split("\n\n").select do |pcidev|
-      pcidev =~ /(?:3D|VGA)(?: compatible) controller/
+      pcidev =~ /(?:3D|VGA)(?: compatible)? controller/
     end.map do |gpudev|
       Mash.new.tap do |properties|
         gpudev.lines.map do |line|

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -71,6 +71,9 @@ nvidia_driver = case nvidia_device
                 when /Tesla M60/
                   # AWS g3 instances
                   'nvidia-driver-470'
+                when /Device 2237/
+                  # AWS g5 instances
+                  'nvidia-driver-470'
                 when nil
                   # it doesn't really matter which driver we use
                   # if there is no nvidia device but specify

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -71,6 +71,9 @@ nvidia_driver = case nvidia_device
                 when /Tesla M60/
                   # AWS g3 instances
                   'nvidia-driver-470'
+                when /Tesla T4/
+                  # AWS g4dn instances
+                  'nvidia-driver-470'
                 when /Device 2237/
                   # AWS g5 instances
                   'nvidia-driver-470'

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -55,12 +55,13 @@ end
 if has_nvidia_support? and nvidia_devices.size != 1
   Chef::Log.warn("There are multiple nvidia devices and I am only looking at the first!")
 end
+nvidia_device = if has_nvidia_support?
+                  nvidia_devices.first['device']
+                else
+                  nil
+                end
 
-# GeForce GTX 550 Ti requires old 3xx.xx series
-# GRID K520 could probably take newer but is working with the current driver.
-#
-# 470 for everything else is not the newest but it works :shrug:
-nvidia_driver = case nvidia_devices.first['device']
+nvidia_driver = case nvidia_device
                 when /GTX 550/
                   # Old optimus machine in OSRF office
                   'nvidia-384'
@@ -70,6 +71,12 @@ nvidia_driver = case nvidia_devices.first['device']
                 when /Tesla M60/
                   # AWS g3 instances
                   'nvidia-driver-470'
+                when nil
+                  # it doesn't really matter which driver we use
+                  # if there is no nvidia device but specify
+                  # one to avoid a warning.
+                  'nvidia-driver-470'
+
                 else
                   Chef::Log.warn("Untested GPU `#{nvidia_devices.first['device']}` being used. Assuming a functioning driver")
                   'nvidia-driver-470'

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -82,7 +82,6 @@ nvidia_driver = case nvidia_device
                   # if there is no nvidia device but specify
                   # one to avoid a warning.
                   'nvidia-driver-470'
-
                 else
                   Chef::Log.warn("Untested GPU `#{nvidia_devices.first['device']}` being used. Assuming a functioning driver")
                   'nvidia-driver-470'


### PR DESCRIPTION
This PR started because we were trying to use the g5.xlarge instances which had slightly different lspci output from what the current detector expected. In the end I also added support for different nvidia drivers depending on the detected hardware as the old driver required for supporting optimus was too old to support the hardware in g4n and g5 AWS instances.

As part of these changes, I also moved GPU detection into a plugin for chef's ohai utlity, which profiles a system on chef startup so its attributes are available to chef cookbooks, so I could use more information about these GPUs in other parts of the cookbook beyond only_if and not_if predicates.

---

The g5.xlarge instances we are trying to deploy have the following lspci output:

```
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma]
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.3 Non-VGA unclassified device: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 08)
00:03.0 VGA compatible controller: Amazon.com, Inc. Device 1111
00:04.0 Non-Volatile memory controller: Amazon.com, Inc. Device 8061
00:05.0 Ethernet controller: Amazon.com, Inc. Elastic Network Adapter (ENA)
00:1e.0 3D controller: NVIDIA Corporation Device 2237 (rev a1)
00:1f.0 Non-Volatile memory controller: Amazon.com, Inc. NVMe SSD Controller
 ```

(Note the use of 3D controller rather than VGA compatible controller)
This updates the nvidia detection to try and use this.

Since this does not match the nvidia grid output from the existing AWS
support I did not update that to use it.

Further iteration may be required to get these working.