### PR TITLE
Refactor GPU agent testing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     name: 20.04 (${{ matrix.suite }} \
-          chef ${{ matrix.chef_version }} \
-          fake-nvidia ${{ matrix.nvidia_support }})
+          chef ${{ matrix.chef_version }})
     strategy:
       matrix:
         suite:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,15 +24,10 @@ jobs:
         suite:
           - 'agent'
           - 'agent-only'
+          - 'gpu-agent'
         chef_version:
           - '16'
           - '17'
-        nvidia_support:
-          - true
-          - false
-        exclude:
-          - suite: 'agent-only'
-            nvidia_support: true
       fail-fast: false
     steps:
       - name: check out code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
           CHEF_LICENSE: accept-no-persist
           CHEF_VERSION: ${{ matrix.chef_version }}
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
-          CHEF_TEST_FAKE_NVIDIA_SUPPORT: ${{ matrix.nvidia_support }}
       - name: Print debug output (lightdm)
         if: failure()
         run: |

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -6,8 +6,6 @@ driver:
   privileged: true
   env:
     - CHEF_LICENSE=accept
-    # yamllint disable-line rule:line-length
-    - CHEF_TEST_FAKE_NVIDIA_SUPPORT=<%= ENV['CHEF_TEST_FAKE_NVIDIA_SUPPORT'] || false %>
 
 transport:
   name: dokken

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -54,3 +54,22 @@ suites:
         - test/integration/agent
         - test/integration/x11_no_support
         - test/integration/my_custom_name
+  - name: gpu-agent
+    data_bags_path: "test/integration/data_bags"
+    run_list:
+      - recipe[osrf_jenkins_agent]
+    attributes:
+      'gpu_devices':
+        '0d:00.0':
+          slot: '0d:00.0'
+          class: VGA compatible controller
+          vendor: mock NVIDIA
+          device: mock TU104GL [Tesla T4]
+          svendor: mock NVIDIA
+          sdevice: mock TU104GL [Tesla T4]
+          physlot: '30'
+          rev: a1
+    verifier:
+      inspec_tests:
+        - test/integration/agent
+        - test/integration/x11_support

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,9 +17,6 @@ module OSRFJenkinsAgent
     #
     # @return [Boolean]
     def has_nvidia_support?
-      if ENV['CHEF_TEST_FAKE_NVIDIA_SUPPORT'] == 'true'
-        return true
-      end
       nvidia_devices.any?
     end
 


### PR DESCRIPTION
I broke support for the mock nvidia GPU support with #39 since nvidia support is still reported but no nvidia devices are actually present.

In order to fix this, I'm trialing the removal of the environment-based detector overrides and instead mocking the ohai-provided attributes that we now use for GPU detection.

The other option would be to insert a device when the environment variable is detected, but I think that using mocked attributes is probably closer to the intended / recommended method of handling node differences in tests.