### PR TITLE
Do not apply docker label to all agents

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,7 @@ name: main
 "on":
   pull_request:
   push:
-    branches:
-      - latest
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,7 +51,6 @@ node_labels = if node['osrfbuild']['agent']['labels']
               else
                 Array.new
               end
-# All default agents are "docker" agents.
 node_name = "linux-#{node_base_name}.focal"
 
 if has_nvidia_support?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,9 +52,6 @@ node_labels = if node['osrfbuild']['agent']['labels']
                 Array.new
               end
 # All default agents are "docker" agents.
-if node['osrfbuild']['agent']['auto_generate_labels']
-  node_labels << 'docker' unless node_labels.include? 'docker'
-end
 node_name = "linux-#{node_base_name}.focal"
 
 if has_nvidia_support?

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -38,6 +38,6 @@ control 'check-no-default-label' do
   impact 'high'
   title 'Check that no default label is being applied. arm agents do not use docker'
   describe file('/etc/default/jenkins-agent') do
-    its('content') { should match /LABELS=''/ }
+    its('content') { should match /LABELS='.*docker.*'/ }
   end
 end

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -34,7 +34,7 @@ control 'check-no-nil-in-agents' do
   end
 end
 
-control 'check-no-default-dcoker-label' do
+control 'check-no-default-docker-label' do
   impact 'high'
   title 'Check that no default docker label is being applied. Historically meant amd64-docker systems'
   describe file('/etc/default/jenkins-agent') do

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -38,6 +38,6 @@ control 'check-no-default-label' do
   impact 'high'
   title 'Check that no default label is being applied. arm agents do not use docker'
   describe file('/etc/default/jenkins-agent') do
-    its('content') { should match /LABELS='.*docker.*'/ }
+    its('content') { should_not match /LABELS='.*docker.*'/ }
   end
 end

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -34,9 +34,9 @@ control 'check-no-nil-in-agents' do
   end
 end
 
-control 'check-no-default-label' do
+control 'check-no-default-dcoker-label' do
   impact 'high'
-  title 'Check that no default label is being applied. arm agents do not use docker'
+  title 'Check that no default docker label is being applied. Historically meant amd64-docker systems'
   describe file('/etc/default/jenkins-agent') do
     its('content') { should_not match /LABELS='.*docker.*'/ }
   end

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -33,3 +33,11 @@ control 'check-no-nil-in-agents' do
     its('content') { should_not match /nil/ }
   end
 end
+
+control 'check-no-default-label' do
+  impact 'high'
+  title 'Check that no default label is being applied. arm agents do not use docker'
+  describe file('/etc/default/jenkins-agent') do
+    its('content') { should match /LABELS=''/ }
+  end
+end


### PR DESCRIPTION
The `docker` label has traditionally implied in the buildfarm that the agent has docker on top of amd64 system. We had the problem of adding `docker` to arm agents making them to be used as debbuilders and generating arm packages instead of the amd64 expected ones. The PR removes the addition of `docker` by default to all agents, something that should be controlled via role.