### PR TITLE
Add python empy package to support ros_buildfarm jobs

### DIFF
--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -30,6 +30,8 @@ end
   mercurial
   ntp
   pciutils
+  python-empy
+  python3-empy
   python-psutil
   python3-psutil
   python-setuptools

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -30,7 +30,6 @@ end
   mercurial
   ntp
   pciutils
-  python-empy
   python3-empy
   python-psutil
   python3-psutil


### PR DESCRIPTION
The empy packages should support the execution of ros_buildfarm generated jobs in the simulation buildfarm.