### PR TITLE
Adapt jenkins agents to be able to use ros_buildfarm code

### DIFF
--- a/files/lightdm/xhost.sh
+++ b/files/lightdm/xhost.sh
@@ -6,3 +6,4 @@ fi
 
 xhost +si:localuser:root
 xhost +si:localuser:jenkins
+xhost +si:localuser:ubuntu  # for using with ros_buildfarm code

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -148,6 +148,12 @@ package 'ubuntu-session' do
   action :purge
 end
 
+# Breaking X loading on AWS
+package 'pulseaudio-module-bluetooth' do
+  only_if { has_nvidia_support? }
+  action :purge
+end
+
 package "lightdm"
 cookbook_file "/etc/lightdm/xhost.sh" do
   source "lightdm/xhost.sh"

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -98,8 +98,11 @@ nvidia_driver = case nvidia_device
                   'nvidia-driver-470'
                 end
 
-
 package nvidia_driver do
+  only_if { has_nvidia_support? }
+end
+
+package 'mesa-utils' do
   only_if { has_nvidia_support? }
 end
 


### PR DESCRIPTION
Some minor changes to make the agents to build with ros_buildfarm code and updates from AWS.

- Add ubuntu user to xhost since ros_buildfarm code uses it
- Avoid the use of bluetooth
- Add mesa-utils (optional)
