### PR TITLE
Add sonoma and sequoia support

### DIFF
--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -95,6 +95,10 @@ mac_version = case node["platform_version"]
                 "monterey"
               when /\A13\./
                 "ventura"
+              when /\A14\./
+                "sonoma"
+              when /\A15\./
+                "sequoia"
               else
                 Chef::Fatal.log("macOS version #{node["platform_version"]} is not supported by this cookbook")
                 raise


### PR DESCRIPTION
This PR adds sonoma and sequoia as supported platforms for the osrf_jenkins_agent. 
