### PR TITLE
[Crola1702/osrfbuild] Do not use the testing server for CI

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,10 +34,6 @@ suites:
     data_bags_path: "test/integration/data_bags"
     run_list:
       - recipe[osrf_jenkins_agent]
-    attributes:
-      'osrfbuild':
-        'agent':
-          'jenkins_url': 'https://citest.build.osrfoundation.org'
     verifier:
       inspec_tests:
         - test/integration/agent
@@ -51,7 +47,6 @@ suites:
         'agent':
           'install_agent_build_setup': false
           'nodename': "my_custom_name"
-          'jenkins_url': 'https://citest.build.osrfoundation.org'
     verifier:
       inspec_tests:
         - test/integration/agent
@@ -62,9 +57,6 @@ suites:
     run_list:
       - recipe[osrf_jenkins_agent]
     attributes:
-      'osrfbuild':
-        'agent':
-          'jenkins_url': 'https://citest.build.osrfoundation.org'
       'gpu_devices':
         '0d:00.0':
           slot: '0d:00.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -111,5 +111,6 @@ execute 'systemctl-daemon-reload' do
 end
 
 service 'jenkins-agent' do
-  action [:start, :enable]
+  action :enable
+  action :start unless ['test'].include? node.chef_environment
 end

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -17,12 +17,12 @@ end
 
 control 'jenkins-agent' do
   impact 'critical'
-  title 'jenkins-agent service should installed and running'
+  title 'jenkins-agent service should installed but can not run'
   describe service('jenkins-agent') do
     it { should be_installed }
     # imposible to connect to server in tests, should not be up
     it { should be_enabled }
-    it { should be_running }
+    it { should_not be_running }
   end
 end
 

--- a/test/integration/agent/agent.rb
+++ b/test/integration/agent/agent.rb
@@ -17,12 +17,12 @@ end
 
 control 'jenkins-agent' do
   impact 'critical'
-  title 'jenkins-agent service should installed but can not run'
+  title 'jenkins-agent service should installed and enabled'
   describe service('jenkins-agent') do
     it { should be_installed }
-    # imposible to connect to server in tests, should not be up
     it { should be_enabled }
-    it { should_not be_running }
+    # Do not make any assumption about the running state since
+    # it can be running or not depending possibly on connection timeouts    
   end
 end
 


### PR DESCRIPTION
The usage of the testing server to be involved in the CI loop is fragile since it will start failing as soon as the testing server is gone or broken during development. There is no guarantee that it is going to be there.

Instead of that we can assume that the agent service is going be installed and enabled but not running.