### PR TITLE
Move MacOS password to a file instead of using a process argument

### DIFF
--- a/recipes/macos.rb
+++ b/recipes/macos.rb
@@ -148,6 +148,17 @@ directory "/Users/jenkins/jenkins-agent" do
   group "staff"
 end
 
+# Create password file for jenkins agent
+password_file_path = "/Users/jenkins/jenkins-agent/.jenkins-password"
+
+file password_file_path do
+  content jenkins_agent_user['password']
+  owner "jenkins"
+  group "staff"
+  mode "0600"
+  sensitive true
+end
+
 launchd "org.osrfoundation.build.jenkins-agent.plist" do
   path "/Library/LaunchDaemons/org.osrfoundation.build.jenkins-agent.plist"
   keep_alive true
@@ -164,7 +175,7 @@ launchd "org.osrfoundation.build.jenkins-agent.plist" do
     -url #{node['osrfbuild']['agent']['jenkins_url']}
     -name #{agent_name}
     -username #{jenkins_agent_user['username']}
-    -password #{jenkins_agent_user['password']}
+    -passwordFile #{password_file_path}
     -description #{description}
     -mode exclusive
     -executors 1


### PR DESCRIPTION
Following up problems detected in https://github.com/osrf/osrf_jenkins_agent/pull/38#issuecomment-3250151527