### PR TITLE
agent_build_tools: keep the nvidia packages still on a running agent

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,10 +14,14 @@ default['osrfbuild']['agent']['nodename'] = nil
 default['osrfbuild']['agent']['install_agent_build_setup'] = true
 # Packages that unattended-upgrades must not touch on a build agent. Entries are
 # regular expressions anchored at the start of the package name, so a prefix
-# such as 'nvidia-' does not cover 'libnvidia-'; list both.
+# such as 'nvidia-' does not cover 'libnvidia-'; list both. The (?!container)
+# lookahead excludes nvidia-container-toolkit/libnvidia-container*: they don't
+# ship a copy of the driver (they mount the host driver into containers at
+# runtime), so they carry no version-skew risk and should stay eligible for
+# security updates instead of being frozen alongside the driver.
 default['osrfbuild']['agent']['unattended_upgrades']['package_blacklist'] = %w[
-  nvidia-
-  libnvidia-
+  nvidia-(?!container)
+  libnvidia-(?!container)
 ]
 default['osrfbuild']['agent']['jenkins_url'] = "https://default_url.org"
 default['osrfbuild']['agent']['java_args'] = ''

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,13 @@ default['osrfbuild']['agent']['nodename'] = nil
 # If set to false, install just the Jenkins agent connection. Useful for
 # special machines like the package repositories.
 default['osrfbuild']['agent']['install_agent_build_setup'] = true
+# Packages that unattended-upgrades must not touch on a build agent. Entries are
+# regular expressions anchored at the start of the package name, so a prefix
+# such as 'nvidia-' does not cover 'libnvidia-'; list both.
+default['osrfbuild']['agent']['unattended_upgrades']['package_blacklist'] = %w[
+  nvidia-
+  libnvidia-
+]
 default['osrfbuild']['agent']['jenkins_url'] = "https://default_url.org"
 default['osrfbuild']['agent']['java_args'] = ''
 default['osrfbuild']['agent']['username'] = 'default_username'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,12 +13,10 @@ default['osrfbuild']['agent']['nodename'] = nil
 # special machines like the package repositories.
 default['osrfbuild']['agent']['install_agent_build_setup'] = true
 # Packages that unattended-upgrades must not touch on a build agent. Entries are
-# regular expressions anchored at the start of the package name, so a prefix
-# such as 'nvidia-' does not cover 'libnvidia-'; list both. The (?!container)
-# lookahead excludes nvidia-container-toolkit/libnvidia-container*: they don't
+# regular expressions anchored at the start of the package name, 
+# Excluding nvidia-container-toolkit/libnvidia-container*: they don't
 # ship a copy of the driver (they mount the host driver into containers at
-# runtime), so they carry no version-skew risk and should stay eligible for
-# security updates instead of being frozen alongside the driver.
+# runtime).
 default['osrfbuild']['agent']['unattended_upgrades']['package_blacklist'] = %w[
   nvidia-(?!container)
   libnvidia-(?!container)

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -37,6 +37,7 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/agent
+        - test/integration/build_tools
         - test/integration/x11_support
   - name: agent-only
     data_bags_path: "test/integration/data_bags"
@@ -70,4 +71,5 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/agent
+        - test/integration/build_tools
         - test/integration/x11_support

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -123,7 +123,6 @@ if has_nvidia_support?
     not_if %(test -z "$(#{nvidia_packages_to_hold})")
   end
 
-
   package 'mesa-utils'
 
   cookbook_file '/etc/modprobe.d/blacklist-nvidia-nouveau.conf' do

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -105,11 +105,15 @@ if has_nvidia_support?
   #
   # Shell snippet listing the installed nvidia packages that are not held yet.
   # It is used both as the guard and as the input of the hold, so the resource
-  # only runs when there is something left to freeze.
+  # only runs when there is something left to freeze. nvidia-container-toolkit
+  # and libnvidia-container* are excluded: they don't carry a copy of the
+  # driver (they mount the host driver into containers at runtime), so they
+  # are not part of the version-skew problem and should stay upgradable for
+  # security fixes instead of being frozen alongside the driver.
   nvidia_packages_to_hold = <<~'CMD'.strip
     held=$(apt-mark showhold);
     dpkg-query -W -f='${db:Status-Abbrev} ${Package}\n' 'nvidia-*' 'libnvidia-*' 2>/dev/null |
-      awk '$1 ~ /^ii/ { print $2 }' | sort -u |
+      awk '$1 ~ /^ii/ && $2 !~ /container/ { print $2 }' | sort -u |
       while read -r pkg; do echo "$held" | grep -qx "$pkg" || echo "$pkg"; done
   CMD
 

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -85,7 +85,7 @@ if has_nvidia_support?
   execute "install-#{nvidia_driver_package}" do
     command "apt-get install -y --no-install-recommends #{nvidia_driver_package}"
     only_if { has_nvidia_support? }
-    not_if "dpkg-query -W -f='${Status}' #{nvidia_driver_package} 2>/dev/null | grep -q '^install ok installed$'"
+    not_if "dpkg-query -W -f='${db:Status-Status}' #{nvidia_driver_package} 2>/dev/null | grep -q '^installed$'"
   end
 
   # Freeze the nvidia packages so they are never upgraded behind the nvidia.ko

--- a/recipes/agent_build_tools.rb
+++ b/recipes/agent_build_tools.rb
@@ -42,6 +42,19 @@ end
   package pkg
 end
 
+# Keep unattended-upgrades away from packages that cannot be swapped under a
+# running agent. Dropped as a separate file in apt.conf.d so the distribution
+# 50unattended-upgrades keeps providing the rest of the policy.
+template '/etc/apt/apt.conf.d/51unattended-upgrades-osrf' do
+  source '51unattended-upgrades-osrf.erb'
+  mode '0644'
+  owner 'root'
+  group 'root'
+  variables(
+    blacklist: node['osrfbuild']['agent']['unattended_upgrades']['package_blacklist']
+  )
+end
+
 if has_nvidia_support?
   apt_repository "nvidia-container-toolkit" do
     uri 'https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH)'
@@ -67,10 +80,43 @@ if has_nvidia_support?
   # 6.17 does not export, so nvidia-drm.ko fails to load and X falls back
   # to software rendering. 535 is the latest branch whose module loads
   # cleanly on the current Noble aws kernel.
-  execute 'install-nvidia-535-server' do
-    command 'apt-get install -y --no-install-recommends nvidia-driver-535-server'
+  nvidia_driver_package = 'nvidia-driver-535-server'
+
+  execute "install-#{nvidia_driver_package}" do
+    command "apt-get install -y --no-install-recommends #{nvidia_driver_package}"
     only_if { has_nvidia_support? }
-    not_if "dpkg-query -W -f='${Status}' nvidia-driver-535-server 2>/dev/null | grep -q '^install ok installed$'"
+    not_if "dpkg-query -W -f='${Status}' #{nvidia_driver_package} 2>/dev/null | grep -q '^install ok installed$'"
+  end
+
+  # Freeze the nvidia packages so they are never upgraded behind the nvidia.ko
+  # that is already loaded. When that happens the agent keeps looking healthy
+  # to lspci while every GPU job fails at container start with
+  #   failed to initialize NVML: Driver/library version mismatch
+  # and it stays that way until the machine is rebooted.
+  #
+  # Hold the installed packages rather than just the metapackage: on noble
+  # nvidia-driver-535-server is a transitional package whose dependency on
+  # nvidia-driver-580-server carries no version, so holding it alone would not
+  # keep the components still.
+  #
+  # This complements the unattended-upgrades blacklist above, which only covers
+  # the automatic path. Upgrading the driver is a deliberate operation:
+  # apt-mark unhold, converge, reboot.
+  #
+  # Shell snippet listing the installed nvidia packages that are not held yet.
+  # It is used both as the guard and as the input of the hold, so the resource
+  # only runs when there is something left to freeze.
+  nvidia_packages_to_hold = <<~'CMD'.strip
+    held=$(apt-mark showhold);
+    dpkg-query -W -f='${db:Status-Abbrev} ${Package}\n' 'nvidia-*' 'libnvidia-*' 2>/dev/null |
+      awk '$1 ~ /^ii/ { print $2 }' | sort -u |
+      while read -r pkg; do echo "$held" | grep -qx "$pkg" || echo "$pkg"; done
+  CMD
+
+  execute 'hold-nvidia-packages' do
+    command "#{nvidia_packages_to_hold} | xargs -r apt-mark hold"
+    only_if { has_nvidia_support? }
+    not_if %(test -z "$(#{nvidia_packages_to_hold})")
   end
 
 

--- a/templates/51unattended-upgrades-osrf.erb
+++ b/templates/51unattended-upgrades-osrf.erb
@@ -1,0 +1,17 @@
+// Managed by Chef (osrf_jenkins_agent). Local changes will be overwritten.
+//
+// APT merges list values across apt.conf.d files, so this only adds to the
+// distribution defaults in 50unattended-upgrades instead of replacing them.
+//
+// Packages listed here break a running build agent when they are upgraded in
+// place. The NVIDIA driver is the motivating case: an upgrade replaces the
+// userspace libraries while the previously loaded nvidia.ko stays in memory,
+// and from that moment every GPU job on the agent fails at container start
+// with "failed to initialize NVML: Driver/library version mismatch" until the
+// machine is rebooted. Driver updates are done deliberately instead:
+// apt-mark unhold, converge, reboot.
+Unattended-Upgrade::Package-Blacklist {
+<% @blacklist.each do |pkg| -%>
+        "<%= pkg %>";
+<% end -%>
+};

--- a/test/integration/build_tools/build_tools.rb
+++ b/test/integration/build_tools/build_tools.rb
@@ -1,0 +1,22 @@
+# Checks for the osrf_jenkins_agent::agent_build_tools recipe. Only used by the
+# suites that set install_agent_build_setup, so it must not be added to the
+# agent-only suite.
+
+control 'unattended-upgrades-blacklist' do
+  impact 'high'
+  title 'Packages that break a running agent when upgraded in place are excluded from unattended-upgrades'
+  describe file('/etc/apt/apt.conf.d/51unattended-upgrades-osrf') do
+    it { should exist }
+    # 'nvidia-' does not cover 'libnvidia-': the entries are regexps anchored
+    # at the start of the package name
+    its('content') { should match /"nvidia-";/ }
+    its('content') { should match /"libnvidia-";/ }
+  end
+
+  # The distribution 50unattended-upgrades must keep providing the rest of the
+  # policy, so check the merged value and not only our own file
+  describe command('apt-config dump Unattended-Upgrade::Package-Blacklist') do
+    its('stdout') { should match /"nvidia-"/ }
+    its('stdout') { should match /"libnvidia-"/ }
+  end
+end

--- a/test/integration/build_tools/build_tools.rb
+++ b/test/integration/build_tools/build_tools.rb
@@ -8,15 +8,19 @@ control 'unattended-upgrades-blacklist' do
   describe file('/etc/apt/apt.conf.d/51unattended-upgrades-osrf') do
     it { should exist }
     # 'nvidia-' does not cover 'libnvidia-': the entries are regexps anchored
-    # at the start of the package name
-    its('content') { should match /"nvidia-";/ }
-    its('content') { should match /"libnvidia-";/ }
+    # at the start of the package name, so both prefixes are listed. The
+    # (?!container) lookahead keeps nvidia-container-toolkit and
+    # libnvidia-container* out of the freeze: they mount the host driver into
+    # containers instead of shipping a copy of it, so they carry no
+    # version-skew risk and must stay eligible for security updates.
+    its('content') { should match /"nvidia-\(\?!container\)";/ }
+    its('content') { should match /"libnvidia-\(\?!container\)";/ }
   end
 
   # The distribution 50unattended-upgrades must keep providing the rest of the
   # policy, so check the merged value and not only our own file
   describe command('apt-config dump Unattended-Upgrade::Package-Blacklist') do
-    its('stdout') { should match /"nvidia-"/ }
-    its('stdout') { should match /"libnvidia-"/ }
+    its('stdout') { should match /"nvidia-\(\?!container\)"/ }
+    its('stdout') { should match /"libnvidia-\(\?!container\)"/ }
   end
 end

--- a/test/integration/x11_support/x11_support.rb
+++ b/test/integration/x11_support/x11_support.rb
@@ -25,7 +25,7 @@ control 'nvidia-packages-on-hold' do
   # on agents without a GPU. Match any nvidia-driver-* so the check does not
   # silently turn into a no-op the next time the driver branch is bumped.
   only_if('an nvidia driver is installed') do
-    command("dpkg-query -W -f='${db:Status-Abbrev} ${Package}\\n' 'nvidia-driver-*' 2>/dev/null | grep -q '^ii'").exit_status.zero?
+    command("dpkg-query -W -f='${db:Status-Status} ${Package}\\n' 'nvidia-driver-*' 2>/dev/null | grep -q '^installed'").exit_status.zero?
   end
 
   describe command('apt-mark showhold') do

--- a/test/integration/x11_support/x11_support.rb
+++ b/test/integration/x11_support/x11_support.rb
@@ -30,5 +30,16 @@ control 'nvidia-packages-on-hold' do
 
   describe command('apt-mark showhold') do
     its('stdout') { should match /^nvidia-/ }
+    # The container stack is deliberately left out of the freeze: it detects
+    # the host driver at runtime and mounts the matching host libraries into
+    # containers, so it never skews against the loaded nvidia.ko and must keep
+    # receiving security updates.
+    its('stdout') { should_not match /container/ }
+  end
+
+  # Without this the exclusion checked above would also pass on a machine where
+  # the container stack simply is not installed.
+  describe package('nvidia-container-toolkit') do
+    it { should be_installed }
   end
 end

--- a/test/integration/x11_support/x11_support.rb
+++ b/test/integration/x11_support/x11_support.rb
@@ -17,3 +17,18 @@ control 'lightdm' do
       it { should be_installed }
   end
 end
+
+control 'nvidia-packages-on-hold' do
+  impact 'critical'
+  title 'nvidia packages are held so they are never upgraded behind the loaded nvidia.ko'
+  # Only meaningful once a driver is actually installed, which does not happen
+  # on agents without a GPU. Match any nvidia-driver-* so the check does not
+  # silently turn into a no-op the next time the driver branch is bumped.
+  only_if('an nvidia driver is installed') do
+    command("dpkg-query -W -f='${db:Status-Abbrev} ${Package}\\n' 'nvidia-driver-*' 2>/dev/null | grep -q '^ii'").exit_status.zero?
+  end
+
+  describe command('apt-mark showhold') do
+    its('stdout') { should match /^nvidia-/ }
+  end
+end


### PR DESCRIPTION
Together with https://github.com/gazebo-tooling/release-tools/pull/1525

Upgrading the nvidia packages in place replaces the userspace libraries while the previously loaded nvidia.ko stays in memory. From that moment lspci still reports the driver as in use, so the agent looks healthy and keeps accepting work, but every GPU job dies at container start with

  failed to initialize NVML: Driver/library version mismatch

and it stays broken until the machine is rebooted. One agent in that state fails every GPU job it picks up, e.g.
https://build.osrfoundation.org/job/gz_sim-ci-pr_any-noble-amd64/2521/

Nothing protected these packages so far: unattended-upgrades is on by default for the security pocket, and nvidia driver updates are published there. Cover both paths:

- an unattended-upgrades blacklist, following what the ros_buildfarm cookbook already does for docker.io/containerd/openjdk. It is dropped as a separate file in apt.conf.d because APT merges list values across files, so the distribution policy in 50unattended-upgrades is kept. The entries are regexps anchored at the start of the package name, so 'nvidia-' does not cover 'libnvidia-' and both are listed.

- an apt-mark hold, which also stops a manual apt-get upgrade. The hold covers the installed packages instead of only the metapackage: on noble nvidia-driver-535-server has become a transitional package whose dependency on nvidia-driver-580-server carries no version, so holding it alone would not keep the components still.

Driver updates become a deliberate operation: apt-mark unhold, converge, reboot.

Assisted-by: Claude Opus 5